### PR TITLE
fix private endpoint when location is optional

### DIFF
--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -2,7 +2,7 @@
 resource "azurerm_private_endpoint" "this" {
   for_each                      = var.private_endpoints
   name                          = each.value.name != null ? each.value.name : "pe-${var.name}"
-  location                      = each.value.location != null ? each.value.location : coalesce(var.location, data.azurerm_resource_group.parent[0].location)
+  location                      = coalesce(each.value.location, var.location, data.azurerm_resource_group.parent[0].location)
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
   subnet_id                     = each.value.subnet_resource_id
   custom_network_interface_name = each.value.network_interface_name

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -2,7 +2,7 @@
 resource "azurerm_private_endpoint" "this" {
   for_each                      = var.private_endpoints
   name                          = each.value.name != null ? each.value.name : "pe-${var.name}"
-  location                      = each.value.location != null ? each.value.location : var.location
+  location                      = each.value.location != null ? each.value.location : coalesce(var.location, data.azurerm_resource_group.parent[0].location)
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
   subnet_id                     = each.value.subnet_resource_id
   custom_network_interface_name = each.value.network_interface_name


### PR DESCRIPTION
```var.location``` can now be null, needs to follow the same pattern as used for the resource group location.

@matt-FFFFFF flagging this will need an update here as well:
https://azure.github.io/Azure-Verified-Modules/specs/shared/interfaces/#private-endpoints

