### PR TITLE
enhancement: improve clean up with new e2e test method

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,7 @@ jobs:
       matrix:
         example: ${{ fromJson(needs.getexamples.outputs.examples) }}
       max-parallel: 5
+      fail-fast: false
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 


### PR DESCRIPTION
Moving to the container solution to run the tests has removed the separate destroy step with had the `always()` condition. This results in the destroy not been run if another matrix test fails. The results in test artefacts not being cleaned up and a manual process required to clean them up,

This PR adds the `fail-fast: false` flag to ensure all parallel tests run to conclusion, including the deferred and retried destroy step in the new library.