### PR TITLE
feat: break up linting jobs

### DIFF
--- a/.github/actions/avmfix/action.yml
+++ b/.github/actions/avmfix/action.yml
@@ -1,10 +1,6 @@
 author: AVM
 name: avmfix
 description: Ensures that avmfix has been run.
-inputs:
-  github-token:
-    description: The GitHub token
-    required: true
 
 runs:
   using: composite
@@ -21,8 +17,11 @@ runs:
           echo "No changes detected"
           exit 0
         else
-          echo "Autofix changes detected, please run:"
-          echo "> docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform make autofix"
+          echo "AVMfix changes detected, please run:"
+          echo "> docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform make pre-commit"
+          echo "... or if you have the avm helper script installed:"
+          echo "> ./avm pre-commit"
+          echo "> avm.bat pre-commit (on Windows)"
           echo
           echo "Then commit and push the changes"
           exit 1

--- a/.github/actions/avmfix/action.yml
+++ b/.github/actions/avmfix/action.yml
@@ -1,0 +1,29 @@
+author: AVM
+name: avmfix
+description: Ensures that avmfix has been run.
+inputs:
+  github-token:
+    description: The GitHub token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: run avmfix
+      shell: bash
+      run: |
+        docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform make autofix
+
+    - name: detect changes
+      shell: bash
+      run: |
+        if [ -z $(git status -s) ]; then
+          echo "No changes detected"
+          exit 0
+        else
+          echo "Autofix changes detected, please run:"
+          echo "> docker run --rm -v $(pwd):/src -w /src mcr.microsoft.com/azterraform make autofix"
+          echo
+          echo "Then commit and push the changes"
+          exit 1
+        fi

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,9 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  linting:
+  docs:
     if: github.event.repository.name != 'terraform-azurerm-avm-template'
-    name: linting
+    name: docs
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
@@ -26,7 +26,28 @@ jobs:
       - name: check docs
         uses: Azure/terraform-azurerm-avm-template/.github/actions/docs-check@main
 
+  terraform:
+    if: github.event.repository.name != 'terraform-azurerm-avm-template'
+    name: terraform
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+
       - name: lint terraform
         uses: Azure/terraform-azurerm-avm-template/.github/actions/linting@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  avmfix:
+    if: github.event.repository.name != 'terraform-azurerm-avm-template' && false
+    name: avmfix
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+
+      - name: autofix
+        uses: Azure/terraform-azurerm-avm-template/.github/actions/autofix@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -48,6 +48,4 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: autofix
-        uses: Azure/terraform-azurerm-avm-template/.github/actions/autofix@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: Azure/terraform-azurerm-avm-template/.github/actions/avmfix@main


### PR DESCRIPTION
This pull request breaks up the linting jobs into separate jobs for linting, docs, and terraform. It also adds a new avmfix job that is currently disabled. This change improves the organization and clarity of the linting process.

Until we have post-push working this is a good way to ensure avmfix has been run as we can use git to detect changes.