### PR TITLE
removing the env secret step from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Things to do:
 1. Create a user-assigned managed identity in your test subscription.
 1. Create a role assignment for the managed identity on your test subscription, use the minimum required role.
 1. Configure federated identity credentials on the user assigned managed identity. Use the GitHub environment.
-1. Create the following environment secrets on the `test` environment:
-   1. AZURE\_CLIENT\_ID
-   1. AZURE\_TENANT\_ID
-   1. AZURE\_SUBSCRIPTION\_ID
 1. Search and update TODOs within the code and remove the TODO comments once complete.
 
 Major version Zero (0.y.z) is for initial development. Anything MAY change at any time. A module SHOULD NOT be considered stable till at least it is major version one (1.0.0) or greater. Changes will always be via new versions being published and no changes will be made to existing published versions. For more details please go to <https://semver.org/>

--- a/_header.md
+++ b/_header.md
@@ -9,10 +9,6 @@ Things to do:
 1. Create a user-assigned managed identity in your test subscription.
 1. Create a role assignment for the managed identity on your test subscription, use the minimum required role.
 1. Configure federated identity credentials on the user assigned managed identity. Use the GitHub environment.
-1. Create the following environment secrets on the `test` environment:
-   1. AZURE_CLIENT_ID
-   1. AZURE_TENANT_ID
-   1. AZURE_SUBSCRIPTION_ID
 1. Search and update TODOs within the code and remove the TODO comments once complete.
 
 > [!IMPORTANT]


### PR DESCRIPTION
As per the feedback from the office hours this isn't need anymore  and the test environment can be setup without having to setup the secrets cc @zioproto 