### PR TITLE
Map two env vars required by grept into container

### DIFF
--- a/avm
+++ b/avm
@@ -18,4 +18,4 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-$CONTAINER_RUNTIME run --pull always --rm -v "$(pwd)":/src -w /src mcr.microsoft.com/azterraform make "$1"
+$CONTAINER_RUNTIME run --pull always --rm -v "$(pwd)":/src -w /src -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make "$1"

--- a/avm.bat
+++ b/avm.bat
@@ -18,6 +18,6 @@ IF "%~1"=="" (
 )
 
 REM Run the make target with CONTAINER_RUNTIME
-%CONTAINER_RUNTIME% run --pull always --rm -v "%cd%":/src -w /src mcr.microsoft.com/azterraform make %1
+%CONTAINER_RUNTIME% run --pull always --rm -v "%cd%":/src -w /src -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make %1
 
 ENDLOCAL


### PR DESCRIPTION
Without these two env vars you cannot run `avm grept-apply`.