### PR TITLE
Update gitignore - Set-AvmGitHubLabels.ps1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ avm.tflint_example.hcl
 
 # MacOS
 .DS_Store
+
+# Powershell scripts for maintainers
+Set-AvmGitHubLabels.ps1


### PR DESCRIPTION
When an AVM bootstrap a new repository the Set-AvmGitHubLabels.ps1 goes downloaded and executed to set the labels to the repository.

This PR updates the gitignore accordingly.