### PR TITLE
Add workflow for automatically syncing GitHub labels to repos from CSV

### DIFF
--- a/.github/workflows/avm.platform.sync-repo-labels-from-csv.yml
+++ b/.github/workflows/avm.platform.sync-repo-labels-from-csv.yml
@@ -1,0 +1,32 @@
+# Workflow for syncing CSV labels to GitHub Labels
+name: avm.platform.sync-repo-labels-from-csv
+
+on:
+  schedule:
+    - cron: 45 11 * * * # Run daily at 3:45 AM PST
+  workflow_dispatch: {}
+
+# Allow one concurrent deployment
+concurrency:
+  group: "labels"
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+  pull-requests: write
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Sync AVM Labels To Repos GitHub Labels
+        run: |
+          Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/Azure-Verified-Modules/main/docs/static/scripts/Set-AvmGitHubLabels.ps1" -OutFile "./Set-AvmGitHubLabels.ps1"
+          ./Set-AvmGitHubLabels.ps1 -RepositoryName "${{ github.repository }}" -CreateCsvLabelExports $false -RemoveExistingLabels $false -NoUserPrompts $true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow in the `.github/workflows/avm.platform.sync-repo-labels-from-csv.yml` file. The workflow is designed to synchronize CSV labels with GitHub Labels. It is scheduled to run daily at 3:45 AM PST and can also be manually triggered. It runs on an Ubuntu environment and uses a PowerShell script to perform the synchronization.

Here are the key changes:

* Added a new GitHub Actions workflow named `avm.platform.sync-repo-labels-from-csv` that runs daily at 3:45 AM PST or can be manually triggered. It allows one concurrent deployment, with newer runs canceling in-progress ones.
* The workflow has write permissions for issues and pull requests. It uses PowerShell as its default shell.
* The job `sync-labels` in the workflow uses a PowerShell script `Set-AvmGitHubLabels.ps1` fetched from the Azure Verified Modules repository to synchronize labels. The script is run with parameters to specify the repository name, not to create CSV label exports, not to remove existing labels, and to suppress user prompts.