### PR TITLE
updated triage automation notifications

### DIFF
--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -22,13 +22,8 @@ configuration:
                 > [!IMPORTANT]
                 > **The "Needs: Triage :mag:" label must be removed once the triage process is complete!**
 
-                <!--
                 > [!TIP]
                 > For additional guidance on how to triage this issue/PR, see the [TF Issue Triage](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/tf-issue-triage/) documentation.
-                -->
-
-                > [!NOTE]
-                > This label was added as per [ITA06](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita06).
 
       - description: 'ITA09 - When #RR is used in an issue, add the "Needs: Author Feedback :ear:" label'
         if:
@@ -43,10 +38,6 @@ configuration:
         then:
           - addLabel:
               label: "Needs: Author Feedback :ear:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Needs: Author Feedback :ear:" label was added as per [ITA09](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita09).
 
       - description: 'ITA10 - When #wontfix is used in an issue, mark it by using the label of "Status: Won''t Fix :broken_heart:"'
         if:
@@ -62,10 +53,6 @@ configuration:
           - addLabel:
               label: "Status: Won't Fix :broken_heart:"
           - closeIssue
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Status: Won't Fix :broken_heart:" label was added and the issue was closed as per [ITA10](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita10).
 
       - description: 'ITA11 - When a reply from anyone to an issue occurs, remove the "Needs: Author Feedback :ear:" label and label with "Needs: Attention :wave:"'
         if:
@@ -82,10 +69,6 @@ configuration:
               label: "Needs: Author Feedback :ear:"
           - addLabel:
               label: "Needs: Attention :wave:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Needs: Author Feedback :ear:" label was removed and the "Needs: Attention :wave:" label was added as per [ITA11](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita11).
 
       - description: "ITA12 - Clean email replies on every comment"
         if:
@@ -119,10 +102,6 @@ configuration:
         then:
           - removeLabel:
               label: "Needs: Triage :mag:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Needs: Triage :mag:" label was removed as per [ITA15](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita15).
 
       - description: 'ITA20 - If the type is feature request, add the "Type: Feature Request :heavy_plus_sign:" label on the issue'
         if:
@@ -140,10 +119,6 @@ configuration:
         then:
           - addLabel:
               label: "Type: Feature Request :heavy_plus_sign:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Type: Feature Request :heavy_plus_sign:" label was added as per [ITA20](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita20).
 
       - description: 'ITA21 - If the type is bug, add the "Type: Bug :bug:" label on the issue'
         if:
@@ -161,10 +136,6 @@ configuration:
         then:
           - addLabel:
               label: "Type: Bug :bug:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Type: Bug :bug:" label was added as per [ITA21](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita21).
 
       - description: 'ITA22 - If the type is security bug, add the "Type: Security Bug :lock:" label on the issue'
         if:
@@ -182,11 +153,6 @@ configuration:
         then:
           - addLabel:
               label: "Type: Security Bug :lock:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Type: Security Bug :lock:" label was added as per [ITA22](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita22).
-
 
       - description: 'ITA23 - Remove the "Status: In PR" label from an issue when it''s closed.'
         if:
@@ -198,7 +164,3 @@ configuration:
         then:
           - removeLabel:
               label: "Status: In PR :point_right:"
-          - addReply:
-              reply: |
-                > [!NOTE]
-                > The "Status: In PR :point_right:" label was removed as per [ITA23](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita23).

--- a/.github/policies/scheduledSearches.yml
+++ b/.github/policies/scheduledSearches.yml
@@ -36,9 +36,6 @@ configuration:
                 > [!TIP]
                 > - To prevent further actions to take effect, the "Status: Response Overdue 🚩" label must be removed, once this issue has been responded to.
                 > - To avoid this rule being (re)triggered, the ""Needs: Triage :mag:" label must be removed as part of the triage process (when the issue is first responded to)!
-
-                > [!NOTE]
-                > This message was posted as per [ITA01TF](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita01tf1-2).
           - addLabel:
               label: "Status: Response Overdue :triangular_flag_on_post:"
 
@@ -68,9 +65,6 @@ configuration:
                 > [!TIP]
                 > - To prevent further actions to take effect, the "Status: Response Overdue 🚩" label must be removed, once this issue has been responded to.
                 > - To avoid this rule being (re)triggered, the ""Needs: Triage :mag:" label must be removed as part of the triage process (when the issue is first responded to)!
-
-                > [!NOTE]
-                > This message was posted as per [ITA01TF](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita01tf1-2).
           - addLabel:
               label: "Status: Response Overdue :triangular_flag_on_post:"
           - assignTo:
@@ -105,9 +99,6 @@ configuration:
                 > [!TIP]
                 > - To avoid this rule being (re)triggered, the "Needs: Triage :mag:" and "Status: Response Overdue :triangular_flag_on_post:" labels must be removed when the issue is first responded to!
                 > - Remove the "Needs: Immediate Attention :bangbang:" label once the issue has been responded to.
-
-                > [!NOTE]
-                > This message was posted as per [ITA02TF](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita02tf1-2).
           - addLabel:
               label: "Needs: Immediate Attention :bangbang:"
 
@@ -137,9 +128,6 @@ configuration:
                 > [!TIP]
                 > - To avoid this rule being (re)triggered, the "Needs: Triage :mag:" and "Status: Response Overdue :triangular_flag_on_post:" labels must be removed when the issue is first responded to!
                 > - Remove the "Needs: Immediate Attention :bangbang:" label once the issue has been responded to.
-
-                > [!NOTE]
-                > This message was posted as per [ITA02TF](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita02tf1-2).
           - addLabel:
               label: "Needs: Immediate Attention :bangbang:"
 
@@ -182,9 +170,6 @@ configuration:
                 > [!TIP]
                 > - To avoid this rule being (re)triggered, the "Needs: Triage :mag:" and "Status: Response Overdue :triangular_flag_on_post:" labels must be removed when the issue is first responded to!
                 > - Remove the "Needs: Immediate Attention :bangbang:" label once the issue has been responded to.
-
-                > [!NOTE]
-                > This message was posted as per [ITA03TF](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita03tf).
           - addLabel:
               label: "Needs: Immediate Attention :bangbang:"
           - assignTo:
@@ -219,9 +204,6 @@ configuration:
                 >   - The "Status: No Recent Activity :zzz:" label must be removed.
                 >   - If applicable, the "Status: Long Term :hourglass_flowing_sand:" or the "Needs: Module Owner :mega:" label must be added.
 
-                > [!NOTE]
-                > This message was posted as per [ITA04](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita04).
-
       - description: 'ITA05A - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
         frequencies:
           - hourly:
@@ -245,9 +227,6 @@ configuration:
 
                 > [!TIP]
                 > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
-
-                > [!NOTE]
-                > This message was posted as per [ITA05](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita05).
           - closeIssue
 
       - description: 'ITA05B - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
@@ -273,7 +252,4 @@ configuration:
 
                 > [!TIP]
                 > In case this issue needs to be reopened (e.g., the author responds after the issue was closed), the "Status: No Recent Activity :zzz:" label must be removed.
-
-                > [!NOTE]
-                > This message was posted as per [ITA05](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/issue-triage-automation/#ita05).
           - closeIssue


### PR DESCRIPTION
## Description

This PR updates triage automation notifications, in line with the changes in the AVM and BRM repos:
- https://github.com/Azure/Azure-Verified-Modules/pull/1012
- https://github.com/Azure/bicep-registry-modules/pull/2193

## Type of Change

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks