### PR TITLE
Add custom tf var from vars and secrets capability

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,9 @@ jobs:
 
       - name: Test example
         shell: bash
+        env:
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+          VARS_CONTEXT: ${{ toJson(vars) }}
         run: |
           set -e
            MAX_RETRIES=10
@@ -56,10 +59,35 @@ jobs:
             echo "Failed to login after $MAX_RETRIES attempts."
             exit 1
           fi
+
+          declare -A secrets
+          eval "$(echo $SECRETS_CONTEXT | jq -r 'to_entries[] | @sh "secrets[\(.key|tostring)]=\(.value|tostring)"')"
+
+          declare -A variables
+          eval "$(echo $VARS_CONTEXT | jq -r 'to_entries[] | @sh "variables[\(.key|tostring)]=\(.value|tostring)"')"
+
+          for key in "${!secrets[@]}"; do
+            if [[ $key = \TF_VAR_* ]]; then
+              lowerKey=$(echo "$key" | tr '[:upper:]' '[:lower:]')
+              finalKey=${lowerKey/tf_var_/TF_VAR_}
+              export "$finalKey"="${secrets[$key]}"
+            fi
+          done
+
+          for key in "${!variables[@]}"; do
+            if [[ $key = \TF_VAR_* ]]; then
+              lowerKey=$(echo "$key" | tr '[:upper:]' '[:lower:]')
+              finalKey=${lowerKey/tf_var_/TF_VAR_}
+              export "$finalKey"="${variables[$key]}"
+            fi
+          done
+
+          echo -e "Custom environment variables:\n$(env | grep TF_VAR_ | grep -v ' "TF_VAR_')"
+
           export ARM_SUBSCRIPTION_ID=$(az login --identity --username $MSI_ID | jq -r '.[0] | .id')
           export ARM_TENANT_ID=$(az login --identity --username $MSI_ID | jq -r '.[0] | .tenantId')
           export ARM_CLIENT_ID=$(az identity list | jq -r --arg MSI_ID "$MSI_ID" '.[] | select(.principalId == $MSI_ID) | .clientId')
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src -w /src --network=host -e TF_IN_AUTOMATION -e TF_VAR_enable_telemetry -e AVM_MOD_PATH=/src -e AVM_EXAMPLE=${{ matrix.example }} -e MSI_ID -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e ARM_USE_MSI=true mcr.microsoft.com/azterraform:latest make test-example
+          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src -w /src --network=host -e TF_IN_AUTOMATION -e TF_VAR_enable_telemetry -e AVM_MOD_PATH=/src -e AVM_EXAMPLE=${{ matrix.example }} -e MSI_ID -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e ARM_USE_MSI=true --env-file <(env | grep TF_VAR_ | grep -v ' "TF_VAR_') mcr.microsoft.com/azterraform:latest make test-example
 
   # This job is only run when all the previous jobs are successful.
   # We can use it for PR validation to ensure all examples have completed.


### PR DESCRIPTION
## Description

This PR adds the capability to send and vars or secrets that start with `TF_VAR_` to the test run as env vars, so that they can be leveraged in the run.

A use case for this is testing with GitHub or Azure DevOps where we need to supply PAT and org name.

Here is an example test run leveraging this code: https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners/actions/runs/10199435253/job/28217447877

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
