### PR TITLE
Add capability to ignore some examples

### DIFF
--- a/.github/actions/e2e-getexamples/action.yml
+++ b/.github/actions/e2e-getexamples/action.yml
@@ -15,15 +15,27 @@ runs:
     - name: get examples
       id: getexamples
       run: |
-        # ls -d */                        = list directories
-        # cut -d/ -f1                     = strip trailing slash from ls output
-        # jq -R -s -c 'split("\n")[:-1]') = creates JSON array:
-        #                                    -R treats the input as string instead of JSON
-        #                                    -s joins all lines into an array
-        #                                    -c creates a compact output
-        #                                    [:-1] removes the last empty string in the output array
-        DIRS="$(ls -d */ | cut -d/ -f1 | jq -R -s -c 'split("\n")[:-1]')"
-        # Set output
+        # Loop through all directories (*/ means all directories ending with a /)
+        DIRS=$(for dir in */; do
+          # Check if the directory does NOT contain a .e2eignore file
+          if [ ! -f "$dir/.e2eignore" ]; then
+            # If the directory does not have a .e2eignore file, include it in the output
+            echo "$dir"
+          fi
+        done |
+        # Remove the trailing slash from each directory name
+        # -d/ specifies the delimiter as "/"
+        # -f1 selects the first field before the delimiter, which is the directory name
+        cut -d/ -f1 |
+        # Convert the list of directory names to a JSON array
+        # -R treats the input as raw strings instead of JSON
+        # -s slurps all lines into a single string
+        # -c generates a compact JSON output
+        # 'split("\n")[:-1]' splits the input into an array based on newline characters
+        # and [:-1] removes the last empty string caused by a trailing newline
+        jq -R -s -c 'split("\n")[:-1]')
+
+        # Set output for GitHub Actions using the $GITHUB_OUTPUT variable
         echo examples="$DIRS" >> "$GITHUB_OUTPUT"
       working-directory: examples
       shell: bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,5 +4,6 @@
 - Create a `_header.md` file in each directory to describe the example.
 - See the `default` example provided as a skeleton - this must remain, but you can add others.
 - Run `make fmt && make docs` from the repo root to generate the required documentation.
+- If you want an example to be ignored by the end to end pipeline add a `.e2eignore` file to the example directory. 
 
 > **Note:** Examples must be deployable and idempotent. Ensure that no input variables are required to run the example and that random values are used to ensure unique resource names. E.g. use the [naming module](https://registry.terraform.io/modules/Azure/naming/azurerm/latest) to generate a unique name for a resource.


### PR DESCRIPTION
## Description

Adds the capability to ignore examples in your end2end pipeline

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
