### PR TITLE
Add AzApi extension to dev container and recommendations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,14 +2,14 @@
   "image": "mcr.microsoft.com/azterraform:latest",
 
   "runArgs": [
-		"--cap-add=SYS_PTRACE",
-		"--security-opt",
-		"seccomp=unconfined",
-		"--init",
-		"--network=host"
-	],
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--init",
+    "--network=host"
+  ],
 
-	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+  "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
   "customizations": {
     "vscode": {
       "settings": {
@@ -18,8 +18,10 @@
         "go.goroot": "/usr/local/go"
       },
       "extensions": [
-        "hashicorp.terraform",
-        "golang.Go"
+        "azapi-vscode.azapi",
+        "EditorConfig.EditorConfig",
+        "golang.Go",
+        "hashicorp.terraform"
       ]
     }
   }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
-    "hashicorp.terraform",
-    "EditorConfig.EditorConfig"
+    "azapi-vscode.azapi",
+    "EditorConfig.EditorConfig",
+    "hashicorp.terraform"
   ]
 }


### PR DESCRIPTION
## Description

Adds the [ Microsoft Terraform AzApi Provider](https://marketplace.visualstudio.com/items?itemName=azapi-vscode.azapi) vscode extension to the dev container extensions and the vscode recommended extensions.

Many of the AVM Terraform modules use the AzApi provider and I think it would be nice to also have the extension installed to help with authoring.

Also adds the EditorConfig extension, that was in the suggested, to the dev container.

Some whitespace diff in the .devcontainer/devcontainer.json was caused because the original file was using CRLF line ending, in contrast to the editorconfig settings and also had mixed tabs and spaces indentation.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
