### PR TITLE
Add `locals.azapi_headers.tf` file

### DIFF
--- a/locals.azapi_headers.tf
+++ b/locals.azapi_headers.tf
@@ -5,11 +5,13 @@ locals {
     "git::https://github\\.com/[A|a]zure/.+",
     "git::ssh:://git@github\\.com/[A|a]zure/.+",
   ]
-  apply_headers = var.enable_telemetry && anytrue([for r in local.valid_module_source_regex : can(regex(r, one(data.modtm_module_source.telemetry).module_source))])
+  fork_avm = !anytrue([for r in local.valid_module_source_regex : can(regex(r, one(data.modtm_module_source.telemetry).module_source))])
   # tflint-ignore: terraform_unused_declarations
-  azapi_headers = local.apply_headers ? {
-    avm = "true"
-    avm_module_source   = one(data.modtm_module_source.telemetry).module_source
-    avm_module_version  = one(data.modtm_module_source.telemetry).module_version
-  } : {}
+  azapi_headers = !var.enable_telemetry ? {} : (local.fork_avm ? {
+    fork_avm = "true"
+    } : {
+    avm                = "true"
+    avm_module_source  = one(data.modtm_module_source.telemetry).module_source
+    avm_module_version = one(data.modtm_module_source.telemetry).module_version
+  })
 }

--- a/locals.azapi_headers.tf
+++ b/locals.azapi_headers.tf
@@ -8,9 +8,11 @@ locals {
   fork_avm = !anytrue([for r in local.valid_module_source_regex : can(regex(r, one(data.modtm_module_source.telemetry).module_source))])
   # tflint-ignore: terraform_unused_declarations
   azapi_headers = !var.enable_telemetry ? {} : (local.fork_avm ? {
-    fork_avm = "true"
+    fork_avm  = "true"
+    random_id = one(random_uuid.telemetry).result
     } : {
     avm                = "true"
+    random_id          = one(random_uuid.telemetry).result
     avm_module_source  = one(data.modtm_module_source.telemetry).module_source
     avm_module_version = one(data.modtm_module_source.telemetry).module_version
   })

--- a/locals.azapi_headers.tf
+++ b/locals.azapi_headers.tf
@@ -1,0 +1,15 @@
+locals {
+  valid_module_source_regex = [
+    "registry.terraform.io/[A|a]zure/.+",
+    "registry.opentofu.io/[A|a]zure/.+",
+    "git::https://github\\.com/[A|a]zure/.+",
+    "git::ssh:://git@github\\.com/[A|a]zure/.+",
+  ]
+  apply_headers = var.enable_telemetry && anytrue([for r in local.valid_module_source_regex : can(regex(r, one(data.modtm_module_source.telemetry).module_source))])
+  # tflint-ignore: terraform_unused_declarations
+  azapi_headers = local.apply_headers ? {
+    avm = "true"
+    avm_module_source   = one(data.modtm_module_source.telemetry).module_source
+    avm_module_version  = one(data.modtm_module_source.telemetry).module_version
+  } : {}
+}


### PR DESCRIPTION
## Description

This pr added new `locals.azapi_headers.tf` file, containing the local expressions that would be merged into all AzAPI resource's customized headers.

`fork_avm` indicates whether the request comes from a forked module, or AVM source. By counting `random_id` we can learn how many forks we have.

If `var.enable_telemetry` is `false`, no headers would be sent.

If `var.enable_telemetry` is `false` and `fork_avm` is `true`, only an uuid ad module instance's ID would be sent.

Otherwise, module's source and version would be sent.
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
