### PR TITLE
replace `azurerm_client_config` with `azapi_client_config`

### DIFF
--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -1,4 +1,4 @@
-data "azurerm_client_config" "telemetry" {
+data "azapi_client_config" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 }
 
@@ -16,8 +16,8 @@ resource "modtm_telemetry" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
   tags = merge({
-    subscription_id = one(data.azurerm_client_config.telemetry).subscription_id
-    tenant_id       = one(data.azurerm_client_config.telemetry).tenant_id
+    subscription_id = one(data.azapi_client_config.telemetry).subscription_id
+    tenant_id       = one(data.azapi_client_config.telemetry).tenant_id
     module_source   = one(data.modtm_module_source.telemetry).module_source
     module_version  = one(data.modtm_module_source.telemetry).module_version
     random_id       = one(random_uuid.telemetry).result

--- a/terraform.tf
+++ b/terraform.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.4"
+    }
     modtm = {
       source  = "azure/modtm"
       version = "~> 0.3"


### PR DESCRIPTION
## Description

Due to [this grept policy](https://github.com/Azure/Azure-Verified-Modules-Grept/blob/74fd169c99e35515fcc16c3a52835f2248c81887/terraform/telemetry.grept.hcl#L3) we should use `azapi_client_config` instead of `azurerm_client_config` as `modtm_telemetry`'s data source. 

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
