### PR TITLE
`fix` - fix incorrect variable syntax in avm.bat

### DIFF
--- a/avm.bat
+++ b/avm.bat
@@ -1,26 +1,26 @@
-@echo on
-SETLOCAL
+@echo off
+SETLOCAL EnableDelayedExpansion
 
 REM Check if this is the original script or a forked copy
 IF NOT DEFINED AVM_FORKED (
     REM Create a temporary directory and file
-    SET TEMP_DIR=%TEMP%\avm_temp_%RANDOM%
-    MKDIR %TEMP_DIR% 2>NUL
-    SET TEMP_FILE=%TEMP_DIR%\avm_%RANDOM%.bat
+    SET TEMP_DIR="%TEMP%\avm_temp_%RANDOM%"
+    MKDIR !TEMP_DIR! 2>NUL
+    SET TEMP_FILE=!TEMP_DIR!\avm_%RANDOM%.bat
 
     REM Copy the current script to the temporary file
-    COPY "avm.bat" %TEMP_FILE% >NUL
+    COPY "avm.bat" !TEMP_FILE! >NUL
 
     REM Execute the temporary file with AVM_FORKED=1 and all original arguments
     SET AVM_FORKED=1
-    CALL %TEMP_FILE% %*
+    CALL !TEMP_FILE! %*
     SET EXIT_CODE=%ERRORLEVEL%
 
     REM Clean up
-    DEL /Q %TEMP_FILE% 2>NUL
-    RMDIR /Q %TEMP_DIR% 2>NUL
+    DEL /Q !TEMP_FILE! 2>NUL
+    RMDIR /Q !TEMP_DIR! 2>NUL
 
-    EXIT /B %EXIT_CODE%
+    EXIT /B !EXIT_CODE!
 )
 
 REM Set CONTAINER_RUNTIME to its current value if it's already set, or docker if it's not


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
